### PR TITLE
Add ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
+ruby '2.2.2'
 source 'https://rubygems.org'
-
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'


### PR DESCRIPTION
Gemfileにバージョンの指定がないと、Heroku上のバージョンがデフォルトで2.0.0になるみたいなので念のため指定しておく。
